### PR TITLE
[fix]退会者のログインで、警告メッセージが表示されなかった不具合の修正

### DIFF
--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Public::SessionsController < Devise::SessionsController
+
+  before_action :reject_customer, only: [:create]
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in
@@ -28,12 +30,12 @@ class Public::SessionsController < Devise::SessionsController
 
   # 退会済みのカスタマーが、ログインできないようにする処理
   # フラッシュメッセージが出力されないため、余裕があれば修正
-    def rejuct_customer
-      customer = Customer.fimd_by(email: params[:customer][:email].downcase)
-      if customer
-        if (customer.valid_password(params[:customer][:password]) && (user.active_for_authentication? == true))
+    def reject_customer
+      @customer = Customer.find_by(email: params[:customer][:email].downcase)
+      if @customer
+        if (@customer.valid_password?(params[:customer][:password]) && (@customer.active_for_authentication? == false))
           flash[:notice] = "このアカウントは退会済みです。アカウントを新規作成してください。"
-          redirect_to new_cuatomer_session_path
+          redirect_to new_customer_session_path
         end
       end
     end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,6 +1,6 @@
 class Address < ApplicationRecord
   belongs_to :customer
   validates :postal_code, length:{is: 7}, numericality: { only_integer: true }
-  validates :address, length:{maximum: 100}
-  validates :name, length:{maximum: 20}
+  validates :address, length:{minimum: 1, maximum: 100}
+  validates :name, length:{minimum: 2, maximum: 20}
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -17,10 +17,10 @@ class Customer < ApplicationRecord
 
 
 
-  enum is_secede_frag: {"退会": true, "有効": false }
+
   #　値が”退会”ならログイン不可能になる処理
   def active_for_authentication?
-    super && (self.is_secede_frag == "有効")
+    super && (self.is_secede_frag == false)
   end
   has_many :cart_items
 end


### PR DESCRIPTION
題の通りです。修正後、正しく表示されることを確認いたしました。
メッセージ自体はcontrollers/public/sessionscontroller.rbに格納してあります。
退会者へのログインメッセージを変更したい場合は、
flash[:notice] = ”~（表示させたい文字）”
この箇所を操作してください。