### PR TITLE
[add]日本時間で表示する機能

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module NAGANOCake
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.time_zone = "Tokyo"
   end
 end

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,5 @@
+# <%= xxx.created_at.to_s(:datetime_jp) %>
+# <%= xxx.updated_at.to_s(:datetime_jp) %>
+# 上記のように入力することで、日本時間で表示が可能になる。
+
+Time::DATE_FORMATS[:datetime_jp] = '%Y年 %m月 %d日 %H時 %M分'


### PR DESCRIPTION
・作業途中です。
・viewにも記載いたしましたが、
<%= xxx.created_at.to_s(:datetime_jp) %>
<%= xxx.updated_at.to_s(:datetime_jp) %>
このように記載することで、日本時間で表示されるようになりました。